### PR TITLE
Fix "ollama-mcp-bridge" script install

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,10 +2,11 @@
 import typer
 import uvicorn
 from loguru import logger
+
 from api import app
 
 
-def main(
+def cli_app(
     config: str = typer.Option("mcp-config.json", "--config", help="Path to MCP config JSON file"),
     host: str = typer.Option("0.0.0.0", "--host", help="Host to bind to"),
     port: int = typer.Option(8000, "--port", help="Port to bind to"),
@@ -24,6 +25,8 @@ def main(
     # Start the server
     uvicorn.run("api:app", host=host, port=port, reload=reload)
 
+def main():
+    typer.run(cli_app)
 
 if __name__ == "__main__":
-    typer.run(main)
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ test = [
 ]
 
 [project.scripts]
-ollama-mcp-bridge = "main:cli_app"
+ollama-mcp-bridge = "main:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/test_unit.py
+++ b/test_unit.py
@@ -3,10 +3,11 @@ Unit tests that can run in GitHub Actions (no external services required)
 Run with: uv run pytest test_unit.py -v
 """
 import json
-import tempfile
 import os
-import sys
+import subprocess
+import tempfile
 from pathlib import Path
+
 
 def test_config_loading():
     """Test that configuration files are loaded correctly"""
@@ -110,3 +111,10 @@ def test_example_config_structure():
             assert "command" in server_config
             assert "args" in server_config
             assert isinstance(server_config["args"], list)
+
+def test_script_installed():
+    try:
+        result = subprocess.run(["ollama-mcp-bridge", "--help"])
+        assert result.returncode == 0
+    except Exception as e:
+        assert False, f"Subprocess call failed. Is the script installed?, {e}"


### PR DESCRIPTION
Hi,

(Many thanks for this simple but effective project.)

Previously the script installed from the pyproject.toml pointed to a missing method of main.py

[project.scripts]
ollama-mcp-bridge = "main:cli_app"  <-- old

[project.scripts]
ollama-mcp-bridge = "main:main"  <-- new

The script needs to point to a method that invokes typer.run, so I added a main() used both as the entry point for the script, and used by main itelf.

if __name__ == "__main__":
    typer.run(main)

To confirm the presence of a working script, a simple test has been added to test_unit.py

