### PR TITLE
feat: add OLLAMA_URL environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ CORS_ORIGINS="http://localhost:3000,http://localhost:8080,https://app.example.co
 ```
 
 **Environment Variables:**
+- `OLLAMA_URL`: URL of the Ollama server (default: `http://localhost:11434`)
+  - Can be overridden with `--ollama-url` CLI parameter
+  - Useful for Docker deployments and configuration management
 - `CORS_ORIGINS`: Comma-separated list of allowed origins (default: `*`)
   - `*` allows all origins (shows warning in logs)
   - Specific origins like `http://localhost:3000,https://myapp.com` for production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,3 @@ services:
     volumes:
       - ./mcp-config.json:/root/mcp-config.json
     restart: unless-stopped
-    command: uv run ollama-mcp-bridge --ollama-url=http://host.docker.internal:11434

--- a/src/ollama_mcp_bridge/main.py
+++ b/src/ollama_mcp_bridge/main.py
@@ -1,5 +1,6 @@
 """Simple CLI entry point for MCP Proxy"""
 import asyncio
+import os
 import typer
 import uvicorn
 from loguru import logger
@@ -12,7 +13,7 @@ def cli_app(
     config: str = typer.Option("mcp-config.json", "--config", help="Path to MCP config JSON file"),
     host: str = typer.Option("0.0.0.0", "--host", help="Host to bind to"),
     port: int = typer.Option(8000, "--port", help="Port to bind to"),
-    ollama_url: str = typer.Option("http://localhost:11434", "--ollama-url", help="Ollama server URL"),
+    ollama_url: str = typer.Option(os.getenv("OLLAMA_URL", "http://localhost:11434"), "--ollama-url", help="Ollama server URL"),
     reload: bool = typer.Option(False, "--reload", help="Enable auto-reload"),
     version: bool = typer.Option(False, "--version", help="Show version information, check for updates and exit"),
 ):


### PR DESCRIPTION
Hi there! 

When trying out this project I noticed that the OLLAMA_URL environment variable mentioned in the docker-compose.yml does not get used anywhere (or maybe I missed it?). 

Changes I made:

- Modify CLI to check OLLAMA_URL environment variable as default
- Update docker-compose.yml to remove hardcoded --ollama-url command (this is not needed anymore)
- Update README.md to document new environment variable
- Maintains backward compatibility with existing --ollama-url CLI parameter (for existing installations)
- Fixes Docker deployment issue where OLLAMA_URL was ignored