### PR TITLE
feat: updating docker-compose for linux users settings. Adding instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ This uses the included [docker-compose.yml](./docker-compose.yml) file which:
 - Maps the configuration file from [./mcp-config.json](./mcp-config.json) (includes mock [weather server for demo](./mock-weather-mcp-server))
 - Allows all CORS origins (configurable via `CORS_ORIGINS` environment variable)
 
+**Platform-specific notes:**
+
+- **macOS & Windows (Docker Desktop)**: Works out of the box. The bridge connects to Ollama on your host using `host.docker.internal:11434`
+
+- **Linux**: By default, Ollama binds to `127.0.0.1:11434` (localhost only), which Docker containers cannot reach. To fix this, run Ollama with:
+  ```bash
+  OLLAMA_HOST=0.0.0.0:11434 ollama serve
+  ```
+  Then start the bridge:
+  ```bash
+  docker-compose up
+  ```
 
 ### Or, install from source
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,11 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - OLLAMA_URL=http://host.docker.internal:11434
+      - OLLAMA_URL=${OLLAMA_URL:-http://host.docker.internal:11434}
       - CORS_ORIGINS=*
     volumes:
       - ./mcp-config.json:/root/mcp-config.json
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
-    command: uv run ollama-mcp-bridge --ollama-url=http://host.docker.internal:11434
+    command: uv run ollama-mcp-bridge --ollama-url=${OLLAMA_URL:-http://host.docker.internal:11434}


### PR DESCRIPTION
Relates to issue #25
---
This pull request improves the Docker setup and documentation for running the Ollama MCP bridge, particularly addressing platform-specific networking issues. The main changes clarify how to connect to Ollama from Docker containers on different operating systems and make the Docker configuration more flexible and robust.

**Documentation updates:**

* Added platform-specific instructions in `README.md` for connecting Docker containers to Ollama, including steps for Linux users to make Ollama accessible from containers.

**Docker configuration improvements:**

* Updated `docker-compose.yml` to allow overriding the `OLLAMA_URL` via environment variables, making the setup more flexible.
* Added `extra_hosts` configuration to ensure `host.docker.internal` resolves correctly inside containers, improving compatibility across platforms.
* Updated the service command in `docker-compose.yml` to use the environment variable for `OLLAMA_URL`, ensuring consistency with the new configuration approach.