### PR TITLE
docs: updating README.md with warning about mcp config when using docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ Create an MCP configuration file at `mcp-config.json` with your servers:
 }
 ```
 
+> [!WARNING]
+> **Docker Command Limitations**: When running in Docker, MCP servers should use commands available in the container:
+> - ✅ `npx` for Node.js-based MCP servers
+> - ✅ `uvx` for Python-based MCP servers
+> - ✅ Direct executables in the container
+> - ❌ `docker` commands (unless Docker-in-Docker is configured)
+> - ❌ Local file paths from your host machine
+
 ### CORS Configuration
 
 Configure Cross-Origin Resource Sharing (CORS) to allow requests from your frontend applications:


### PR DESCRIPTION
Relates to #25 

This pull request updates the documentation to clarify how to configure MCP servers when running in Docker. The most important change is the addition of a warning about command limitations in Docker environments.

**Documentation improvements:**

* Added a warning in the `README.md` explaining which commands are supported for MCP servers running in Docker, including a checklist of allowed and disallowed commands.