### PR TITLE
feat: add configurable max tool rounds and limit handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@
 - 🚀 **Pre-loaded Servers**: All MCP servers are connected at startup from JSON configuration
 - 📝 **JSON Configuration**: Configure multiple servers with complex commands and environments
 - 🔗 **Tool Integration**: Automatic tool call processing and response integration
-- � **Multi-Round Tool Execution**: Automatically loops through multiple rounds of tool calls until completion
-- �🛠️ **All Tools Available**: Ollama can use any tool from any connected server simultaneously
+- 🔄 **Multi-Round Tool Execution**: Automatically loops through multiple rounds of tool calls until completion
+- 🛡️ **Configurable Tool Limits**: Set maximum tool execution rounds to prevent excessive tool calls
+- 🛠️ **All Tools Available**: Ollama can use any tool from any connected server simultaneously
 - 🔌 **Complete API Compatibility**: `/api/chat` adds tools while all other Ollama API endpoints are transparently proxied
 - 🔧 **Configurable Ollama**: Specify custom Ollama server URL via CLI (supports local and cloud models)
 - ☁️ **Cloud Model Support**: Works with Ollama cloud models
@@ -193,12 +194,16 @@ CORS_ORIGINS="http://localhost:3000,http://localhost:8080,https://app.example.co
 ```
 
 **Environment Variables:**
+- `CORS_ORIGINS`: Comma-separated list of allowed origins (default: `*`)
+  - `*` allows all origins (shows warning in logs)
+  - Example: `CORS_ORIGINS="http://localhost:3000,https://myapp.com" ollama-mcp-bridge`
+- `MAX_TOOL_ROUNDS`: Maximum number of tool execution rounds (default: unlimited)
+  - Can be overridden with `--max-tool-rounds` CLI parameter (CLI takes precedence)
+  - Example: `MAX_TOOL_ROUNDS=5 ollama-mcp-bridge`
 - `OLLAMA_URL`: URL of the Ollama server (default: `http://localhost:11434`)
   - Can be overridden with `--ollama-url` CLI parameter
   - Useful for Docker deployments and configuration management
-- `CORS_ORIGINS`: Comma-separated list of allowed origins (default: `*`)
-  - `*` allows all origins (shows warning in logs)
-  - Specific origins like `http://localhost:3000,https://myapp.com` for production
+  - Example: `OLLAMA_URL=http://192.168.1.100:11434 ollama-mcp-bridge`
 
 **CORS Logging:**
 - The bridge logs CORS configuration at startup
@@ -227,8 +232,11 @@ ollama-mcp-bridge --host 0.0.0.0 --port 8080
 # Custom Ollama server URL (local or cloud)
 ollama-mcp-bridge --ollama-url http://192.168.1.100:11434
 
+# Limit tool execution rounds (prevents excessive tool calls)
+ollama-mcp-bridge --max-tool-rounds 5
+
 # Combine options
-ollama-mcp-bridge --config custom.json --host 0.0.0.0 --port 8080 --ollama-url http://remote-ollama:11434
+ollama-mcp-bridge --config custom.json --host 0.0.0.0 --port 8080 --ollama-url http://remote-ollama:11434 --max-tool-rounds 10
 
 # Check version and available updates
 ollama-mcp-bridge --version
@@ -245,6 +253,8 @@ ollama-mcp-bridge --version
 - `--host`: Host to bind the server (default: `0.0.0.0`)
 - `--port`: Port to bind the server (default: `8000`)
 - `--ollama-url`: Ollama server URL (default: `http://localhost:11434`)
+- `--max-tool-rounds`: Maximum tool execution rounds (default: unlimited, can also be set via `MAX_TOOL_ROUNDS` environment variable)
+- `--reload`: Enable auto-reload during development
 - `--version`: Show version information, check for updates and exit
 
 ### API Usage

--- a/src/ollama_mcp_bridge/lifecycle.py
+++ b/src/ollama_mcp_bridge/lifecycle.py
@@ -23,11 +23,13 @@ async def lifespan(fastapi_app: FastAPI):
         # Get config from app state with explicit defaults
         config_file = getattr(fastapi_app.state, 'config_file', 'mcp-config.json')
         ollama_url = getattr(fastapi_app.state, 'ollama_url', 'http://localhost:11434')
+        max_tool_rounds = getattr(fastapi_app.state, 'max_tool_rounds', None)
 
-        logger.info(f"Starting with config file: {config_file}, Ollama URL: {ollama_url}")
+        logger.info(f"Starting with config file: {config_file}, Ollama URL: {ollama_url}, Max tool rounds: {max_tool_rounds if max_tool_rounds else 'unlimited'}")
 
         # Initialize manager and load servers
         mcp_manager = MCPManager(ollama_url=ollama_url)
+        mcp_manager.max_tool_rounds = max_tool_rounds
         await mcp_manager.load_servers(config_file)
 
         # Initialize services

--- a/src/ollama_mcp_bridge/utils.py
+++ b/src/ollama_mcp_bridge/utils.py
@@ -80,8 +80,8 @@ async def iter_ndjson_chunks(chunk_iterator):
         except json.JSONDecodeError as e:
             logger.debug(f"Error parsing trailing NDJSON: {e}")
 
-def validate_cli_inputs(config: str, host: str, port: int, ollama_url: str):
-    """Validate CLI inputs for config file, host, port, and ollama_url."""
+def validate_cli_inputs(config: str, host: str, port: int, ollama_url: str, max_tool_rounds: int = None):
+    """Validate CLI inputs for config file, host, port, ollama_url, and max_tool_rounds."""
     # Validate config file exists
     if not os.path.isfile(config):
         raise BadParameter(f"Config file not found: {config}")
@@ -98,6 +98,10 @@ def validate_cli_inputs(config: str, host: str, port: int, ollama_url: str):
     url_pattern = re.compile(r"^https?://[\w\.-]+(:\d+)?")
     if not url_pattern.match(ollama_url):
         raise BadParameter(f"Invalid Ollama URL: {ollama_url}")
+
+    # Validate max_tool_rounds
+    if max_tool_rounds is not None and max_tool_rounds < 1:
+        raise BadParameter(f"max_tool_rounds must be at least 1, got {max_tool_rounds}")
 
 async def check_for_updates(current_version: str, print_message: bool = False) -> str:
     """

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -131,6 +131,32 @@ def test_example_config_structure():
             assert "args" in server_config
             assert isinstance(server_config["args"], list)
 
+def test_validate_cli_max_tool_rounds():
+    """Test that validate_cli_inputs enforces max_tool_rounds validation."""
+    try:
+        from ollama_mcp_bridge.utils import validate_cli_inputs
+    except ImportError:
+        sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+        from ollama_mcp_bridge.utils import validate_cli_inputs
+
+    # Valid case: None
+    validate_cli_inputs("mcp-config.json", "0.0.0.0", 8000, "http://localhost:11434", None)
+
+    # Invalid max_tool_rounds (zero)
+    from typer import BadParameter
+    try:
+        validate_cli_inputs("mcp-config.json", "0.0.0.0", 8000, "http://localhost:11434", 0)
+        assert False, "Expected BadParameter for max_tool_rounds=0"
+    except BadParameter:
+        pass
+
+    # Invalid max_tool_rounds (negative)
+    try:
+        validate_cli_inputs("mcp-config.json", "0.0.0.0", 8000, "http://localhost:11434", -1)
+        assert False, "Expected BadParameter for max_tool_rounds=-1"
+    except BadParameter:
+        pass
+
 def test_script_installed():
     try:
         result = subprocess.run(["ollama-mcp-bridge", "--help"], check=False)


### PR DESCRIPTION
- Add --max-tool-rounds CLI option and MAX_TOOL_ROUNDS env var support
- Pass max_tool_rounds into app state and MCPManager
- Enforce validation in validate_cli_inputs (must be >= 1)
- Implement round limiting in streaming and non-streaming proxy flows
  (including final LLM call/stream when limit reached)
- Add _make_final_llm_call and _stream_final_llm_call helpers
- Update README with usage and docs for max tool rounds
- Add unit test for max_tool_rounds validation"

---

This pull request introduces a configurable limit for the number of tool execution rounds in the Ollama MCP Bridge, improving control over resource usage and preventing excessive tool calls. The changes include new CLI and environment variable options, updates to the proxy logic to enforce the limit, input validation, and documentation updates.

**Configurable tool execution limits:**

* Added support for `MAX_TOOL_ROUNDS` environment variable and `--max-tool-rounds` CLI option to set the maximum number of tool execution rounds; CLI option takes precedence over environment variable. (`README.md`, `src/ollama_mcp_bridge/main.py`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R197-R206) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R235-R239) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256-R257) [[4]](diffhunk://#diff-7f492131434872d8af98ba814a01eb6ac264e1b9e1a6f8cdaf9e54625a73fc4cR18)
* Proxy logic now enforces the maximum tool rounds in both streaming and non-streaming chat endpoints, making a final LLM call without tools when the limit is reached. (`src/ollama_mcp_bridge/proxy_service.py`, [[1]](diffhunk://#diff-579dda5112adeaa3f471354cf10b9809a240ea23b498453bbc0c2e0f01206848R61-R90) [[2]](diffhunk://#diff-579dda5112adeaa3f471354cf10b9809a240ea23b498453bbc0c2e0f01206848R112-R118) [[3]](diffhunk://#diff-579dda5112adeaa3f471354cf10b9809a240ea23b498453bbc0c2e0f01206848R134-R137) [[4]](diffhunk://#diff-579dda5112adeaa3f471354cf10b9809a240ea23b498453bbc0c2e0f01206848L131-R182)

**Input validation and testing:**

* Enhanced `validate_cli_inputs` to validate `max_tool_rounds` (must be at least 1 if set), and added unit tests for this validation. (`src/ollama_mcp_bridge/utils.py`, `tests/test_unit.py`, [[1]](diffhunk://#diff-bc6e4033a1d3470ff427f6da5f6c167e2f827e85bcd2e0a98a8d099c742a63edL83-R84) [[2]](diffhunk://#diff-bc6e4033a1d3470ff427f6da5f6c167e2f827e85bcd2e0a98a8d099c742a63edR102-R105) [[3]](diffhunk://#diff-6e0c7d0043d4ff88ba528ad3efafdbf7e9e84d544215cc80b30307c1142cd9b0R134-R159)

**Documentation updates:**

* Updated `README.md` to document the new tool round limit feature, including usage examples and environment variable details. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L48-R50) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R197-R206) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R235-R239) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256-R257)

**Lifecycle and logging improvements:**

* Lifecycle startup now logs the configured maximum tool rounds and passes the value to the MCP manager. (`src/ollama_mcp_bridge/lifecycle.py`, [src/ollama_mcp_bridge/lifecycle.pyR26-R32](diffhunk://#diff-ae4164ccf7348134b49d19ad46236bf5eae1c70cad214959eca18fcec98845feR26-R32))

**Code organization:**

* Minor import and typing improvements in CLI entry point for clarity. (`src/ollama_mcp_bridge/main.py`, [src/ollama_mcp_bridge/main.pyL2-R7](diffhunk://#diff-7f492131434872d8af98ba814a01eb6ac264e1b9e1a6f8cdaf9e54625a73fc4cL2-R7))

These changes provide users with better control over tool execution, clearer configuration, and improved reliability.