### PR TITLE
feat: add system prompt cli and envar config option to prepend system message to /api/chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
 - 💻 **Typer CLI**: Clean command-line interface with configurable options
 - 📊 **Structured Logging**: Uses loguru for comprehensive logging
 - 📦 **PyPI Package**: Easily installable via pip or uv from PyPI
-
+- 🗣️ **System Prompt Configuration**: Allows setting a system prompt for the assistant's behavior
 
 ## Requirements
 
@@ -204,6 +204,10 @@ CORS_ORIGINS="http://localhost:3000,http://localhost:8080,https://app.example.co
   - Can be overridden with `--ollama-url` CLI parameter
   - Useful for Docker deployments and configuration management
   - Example: `OLLAMA_URL=http://192.168.1.100:11434 ollama-mcp-bridge`
+- `SYSTEM_PROMPT`: Optional system prompt to prepend to all forwarded `/api/chat` requests
+  - Can be set via the `SYSTEM_PROMPT` environment variable or `--system-prompt` CLI flag
+  - If provided, the bridge will prepend a system message (role: `system`) to the beginning of the `messages` array for `/api/chat` requests unless the request already starts with a system message.
+  - Example: `SYSTEM_PROMPT="You are a concise assistant." ollama-mcp-bridge`
 
 **CORS Logging:**
 - The bridge logs CORS configuration at startup
@@ -235,6 +239,9 @@ ollama-mcp-bridge --ollama-url http://192.168.1.100:11434
 # Limit tool execution rounds (prevents excessive tool calls)
 ollama-mcp-bridge --max-tool-rounds 5
 
+# Set a system prompt to prepend to all /api/chat requests
+ollama-mcp-bridge --system-prompt "You are a concise assistant."
+
 # Combine options
 ollama-mcp-bridge --config custom.json --host 0.0.0.0 --port 8080 --ollama-url http://remote-ollama:11434 --max-tool-rounds 10
 
@@ -253,10 +260,10 @@ ollama-mcp-bridge --version
 - `--host`: Host to bind the server (default: `0.0.0.0`)
 - `--port`: Port to bind the server (default: `8000`)
 - `--ollama-url`: Ollama server URL (default: `http://localhost:11434`)
-- `--max-tool-rounds`: Maximum tool execution rounds (default: unlimited, can also be set via `MAX_TOOL_ROUNDS` environment variable)
+- `--max-tool-rounds`: Maximum tool execution rounds (default: unlimited)
 - `--reload`: Enable auto-reload during development
 - `--version`: Show version information, check for updates and exit
-
+- `--system-prompt`: Optional system prompt to prepend to `/api/chat` requests (default: none)
 ### API Usage
 
 The API is available at `http://localhost:8000`.

--- a/src/ollama_mcp_bridge/lifecycle.py
+++ b/src/ollama_mcp_bridge/lifecycle.py
@@ -24,11 +24,13 @@ async def lifespan(fastapi_app: FastAPI):
         config_file = getattr(fastapi_app.state, 'config_file', 'mcp-config.json')
         ollama_url = getattr(fastapi_app.state, 'ollama_url', 'http://localhost:11434')
         max_tool_rounds = getattr(fastapi_app.state, 'max_tool_rounds', None)
-
         logger.info(f"Starting with config file: {config_file}, Ollama URL: {ollama_url}, Max tool rounds: {max_tool_rounds if max_tool_rounds else 'unlimited'}")
 
+        # Get optional system prompt
+        system_prompt = getattr(fastapi_app.state, 'system_prompt', None)
+
         # Initialize manager and load servers
-        mcp_manager = MCPManager(ollama_url=ollama_url)
+        mcp_manager = MCPManager(ollama_url=ollama_url, system_prompt=system_prompt)
         mcp_manager.max_tool_rounds = max_tool_rounds
         await mcp_manager.load_servers(config_file)
 

--- a/src/ollama_mcp_bridge/main.py
+++ b/src/ollama_mcp_bridge/main.py
@@ -16,6 +16,7 @@ def cli_app(
     port: int = typer.Option(8000, "--port", help="Port to bind to"),
     ollama_url: str = typer.Option(os.getenv("OLLAMA_URL", "http://localhost:11434"), "--ollama-url", help="Ollama server URL"),
     max_tool_rounds: Optional[int] = typer.Option(os.getenv("MAX_TOOL_ROUNDS", None), "--max-tool-rounds", help="Maximum tool execution rounds (default: unlimited)"),
+    system_prompt: Optional[str] = typer.Option(os.getenv("SYSTEM_PROMPT", None), "--system-prompt", help="System prompt to prepend to messages (can also be set with SYSTEM_PROMPT env var)"),
     reload: bool = typer.Option(False, "--reload", help="Enable auto-reload"),
     version: bool = typer.Option(False, "--version", help="Show version information, check for updates and exit"),
 ):
@@ -25,12 +26,13 @@ def cli_app(
         # Check for updates and print if available
         asyncio.run(check_for_updates(__version__, print_message=True))
         raise typer.Exit(0)
-    validate_cli_inputs(config, host, port, ollama_url, max_tool_rounds)
+    validate_cli_inputs(config, host, port, ollama_url, max_tool_rounds, system_prompt)
 
     # Store config in app state so lifespan can access it
     app.state.config_file = config
     app.state.ollama_url = ollama_url
     app.state.max_tool_rounds = max_tool_rounds
+    app.state.system_prompt = system_prompt
 
     logger.info(f"Starting MCP proxy server on {host}:{port}")
     logger.info(f"Using Ollama server: {ollama_url}")

--- a/src/ollama_mcp_bridge/mcp_manager.py
+++ b/src/ollama_mcp_bridge/mcp_manager.py
@@ -12,7 +12,7 @@ from mcp.client.stdio import stdio_client
 class MCPManager:
     """Manager for MCP servers, handling tool definitions and session management."""
 
-    def __init__(self, ollama_url: str = "http://localhost:11434"):
+    def __init__(self, ollama_url: str = "http://localhost:11434", system_prompt: str = None):
         """Initialize MCP Manager
 
         Args:
@@ -22,6 +22,8 @@ class MCPManager:
         self.all_tools: List[dict] = []
         self.exit_stack = AsyncExitStack()
         self.ollama_url = ollama_url
+        # Optional system prompt that can be prepended to messages
+        self.system_prompt = system_prompt
         self.http_client = httpx.AsyncClient()
 
     async def load_servers(self, config_path: str):

--- a/src/ollama_mcp_bridge/utils.py
+++ b/src/ollama_mcp_bridge/utils.py
@@ -80,8 +80,12 @@ async def iter_ndjson_chunks(chunk_iterator):
         except json.JSONDecodeError as e:
             logger.debug(f"Error parsing trailing NDJSON: {e}")
 
-def validate_cli_inputs(config: str, host: str, port: int, ollama_url: str, max_tool_rounds: int = None):
-    """Validate CLI inputs for config file, host, port, ollama_url, and max_tool_rounds."""
+def validate_cli_inputs(config: str, host: str, port: int, ollama_url: str, max_tool_rounds: int = None, system_prompt: str = None):
+    """Validate CLI inputs for config file, host, port, ollama_url, max_tool_rounds and system_prompt.
+
+    Args:
+        system_prompt: optional system prompt string; if provided, must be a non-empty string and not excessively long.
+    """
     # Validate config file exists
     if not os.path.isfile(config):
         raise BadParameter(f"Config file not found: {config}")
@@ -102,6 +106,17 @@ def validate_cli_inputs(config: str, host: str, port: int, ollama_url: str, max_
     # Validate max_tool_rounds
     if max_tool_rounds is not None and max_tool_rounds < 1:
         raise BadParameter(f"max_tool_rounds must be at least 1, got {max_tool_rounds}")
+
+    # Validate system_prompt (if provided)
+    if system_prompt is not None:
+        if not isinstance(system_prompt, str):
+            raise BadParameter("system_prompt must be a string")
+        # Reject empty or whitespace-only prompts
+        if not system_prompt.strip():
+            raise BadParameter("system_prompt must be a non-empty string")
+        # Limit length to a reasonable maximum to avoid excessively large payloads
+        if len(system_prompt) > 10000:
+            raise BadParameter("system_prompt is too long (max 10000 characters)")
 
 async def check_for_updates(current_version: str, print_message: bool = False) -> str:
     """


### PR DESCRIPTION
- Add system prompt cli and envar config option to prepend system message to /api/chat
- Add unit test and update README entry message to /api/chat. Add unit test and update README entry

---

This pull request adds support for configuring a system prompt that can be prepended to all `/api/chat` requests. The system prompt can be set via an environment variable or CLI flag, is validated for correctness, and is only prepended if the incoming message array does not already start with a system message. Documentation and tests have been updated to reflect and verify this new feature.

**System Prompt Feature**

* Added support for an optional system prompt to be prepended to all forwarded `/api/chat` requests, configurable via the `SYSTEM_PROMPT` environment variable or `--system-prompt` CLI flag. The prompt is only added if the first message is not already a system message. (`src/ollama_mcp_bridge/proxy_service.py`, `src/ollama_mcp_bridge/mcp_manager.py`, `src/ollama_mcp_bridge/lifecycle.py`, [[1]](diffhunk://#diff-579dda5112adeaa3f471354cf10b9809a240ea23b498453bbc0c2e0f01206848R21-R34) [[2]](diffhunk://#diff-579dda5112adeaa3f471354cf10b9809a240ea23b498453bbc0c2e0f01206848R100) [[3]](diffhunk://#diff-579dda5112adeaa3f471354cf10b9809a240ea23b498453bbc0c2e0f01206848R142) [[4]](diffhunk://#diff-932dfeac6108176d3a1f1891f7557ce1106070ecb46e84896ee90a5491c868bdL15-R15) [[5]](diffhunk://#diff-932dfeac6108176d3a1f1891f7557ce1106070ecb46e84896ee90a5491c868bdR25-R26) [[6]](diffhunk://#diff-ae4164ccf7348134b49d19ad46236bf5eae1c70cad214959eca18fcec98845feL27-R33)

* Updated CLI and application initialization to accept and pass the system prompt, including validation for non-empty string and reasonable length. (`src/ollama_mcp_bridge/main.py`, `src/ollama_mcp_bridge/utils.py`, [[1]](diffhunk://#diff-bc6e4033a1d3470ff427f6da5f6c167e2f827e85bcd2e0a98a8d099c742a63edL83-R88) [[2]](diffhunk://#diff-bc6e4033a1d3470ff427f6da5f6c167e2f827e85bcd2e0a98a8d099c742a63edR110-R120) [[3]](diffhunk://#diff-7f492131434872d8af98ba814a01eb6ac264e1b9e1a6f8cdaf9e54625a73fc4cR19) [[4]](diffhunk://#diff-7f492131434872d8af98ba814a01eb6ac264e1b9e1a6f8cdaf9e54625a73fc4cL28-R35)

**Documentation**

* Updated `README.md` to describe the new system prompt feature, including configuration examples and CLI/environment variable usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L62-R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R207-R210) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R242-R244) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L256-R266)

**Testing**

* Added a unit test to verify that the system prompt is prepended correctly and not duplicated if a system message is already present. Also updated existing tests to accommodate the new argument. (`tests/test_unit.py`, [[1]](diffhunk://#diff-6e0c7d0043d4ff88ba528ad3efafdbf7e9e84d544215cc80b30307c1142cd9b0L143-R155) [[2]](diffhunk://#diff-6e0c7d0043d4ff88ba528ad3efafdbf7e9e84d544215cc80b30307c1142cd9b0R166-R196)