### PR TITLE
feat: add remote MCP server support with config variable expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@
 
 - 🚀 **Pre-loaded Servers**: All MCP servers are connected at startup from JSON configuration
 - 📝 **JSON Configuration**: Configure multiple servers with complex commands and environments
+- 🌐 **Remote MCP Support**: Connect to MCP servers over HTTP (StreamableHTTP) or SSE (when the URL ends with `/sse`)
+- 🧩 **Config Variable Expansion**: Supports `${env:VAR_NAME}` and `${workspaceFolder}` in config strings
 - 🔗 **Tool Integration**: Automatic tool call processing and response integration
 - 🔄 **Multi-Round Tool Execution**: Automatically loops through multiple rounds of tool calls until completion
 - 🛡️ **Configurable Tool Limits**: Set maximum tool execution rounds to prevent excessive tool calls
@@ -158,6 +160,12 @@ Create an MCP configuration file at `mcp-config.json` with your servers:
         "MCP_LOG_LEVEL": "ERROR"
       }
     },
+    "remote_streamable_http": {
+      "url": "https://example.com/mcp"
+    },
+    "remote_sse": {
+      "url": "https://example.com/sse"
+    },
     "filesystem": {
       "command": "npx",
       "args": [
@@ -165,6 +173,39 @@ Create an MCP configuration file at `mcp-config.json` with your servers:
         "@modelcontextprotocol/server-filesystem",
         "/tmp"
       ]
+    }
+  }
+}
+```
+
+You can configure MCP servers in two ways:
+- **Local process**: `{"command": "...", "args": [...], "env": {...}}`
+- **Remote endpoint**: `{"url": "https://..."}`
+  - If the URL ends with `/sse`, the bridge connects via SSE. Otherwise it uses StreamableHTTP.
+
+The config also supports simple expansion in any string value:
+- `${workspaceFolder}` resolves to the directory containing the config file
+- `${env:VAR_NAME}` resolves to the corresponding environment variable
+
+Example:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "${workspaceFolder}/data"
+      ]
+    },
+    "remote_with_headers": {
+      "url": "https://example.com/mcp",
+      "headers": {
+        "X-Client-Name": "ollama-mcp-bridge",
+        "X-Request-Tag": "${env:MCP_REQUEST_TAG}"
+      }
     }
   }
 }

--- a/tests/test_env_expansion.py
+++ b/tests/test_env_expansion.py
@@ -1,0 +1,43 @@
+
+import os
+import sys
+from pathlib import Path
+
+# Add src directory to path
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root / "src"))
+
+from ollama_mcp_bridge.utils import expand_env_vars, expand_dict_env_vars
+
+def test_expand_env_vars():
+    os.environ["TEST_VAR"] = "test_value"
+
+    assert expand_env_vars("normal string") == "normal string"
+    assert expand_env_vars("${env:TEST_VAR}") == "test_value"
+    assert expand_env_vars("prefix ${env:TEST_VAR} suffix") == "prefix test_value suffix"
+
+    cwd = os.getcwd()
+    assert expand_env_vars("${workspaceFolder}") == cwd
+
+    custom_cwd = "/tmp/custom"
+    assert expand_env_vars("${workspaceFolder}", cwd=custom_cwd) == custom_cwd
+
+def test_expand_dict_env_vars():
+    os.environ["TEST_VAR"] = "test_value"
+    cwd = os.getcwd()
+
+    data = {
+        "key1": "value1",
+        "key2": "${env:TEST_VAR}",
+        "key3": ["item1", "${workspaceFolder}"],
+        "key4": {
+            "nested": "${env:TEST_VAR}"
+        }
+    }
+
+    expanded = expand_dict_env_vars(data)
+
+    assert expanded["key1"] == "value1"
+    assert expanded["key2"] == "test_value"
+    assert expanded["key3"] == ["item1", cwd]
+    assert expanded["key4"]["nested"] == "test_value"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -1,0 +1,63 @@
+
+import pytest
+import json
+import tempfile
+import os
+from ollama_mcp_bridge.mcp_manager import MCPManager
+
+@pytest.fixture
+def anyio_backend():
+    return 'asyncio'
+
+@pytest.mark.anyio
+async def test_invalid_json_config():
+    manager = MCPManager()
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        f.write("{invalid_json")
+        config_path = f.name
+
+    try:
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            await manager.load_servers(config_path)
+    finally:
+        os.unlink(config_path)
+
+@pytest.mark.anyio
+async def test_missing_mcp_servers_key():
+    manager = MCPManager()
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump({"other_key": {}}, f)
+        config_path = f.name
+
+    try:
+        with pytest.raises(ValueError, match="missing 'mcpServers' key"):
+            await manager.load_servers(config_path)
+    finally:
+        os.unlink(config_path)
+
+@pytest.mark.anyio
+async def test_connection_failure_handling():
+    manager = MCPManager()
+    # Config with one valid (mocked later if needed, but here we expect failure) and one invalid server
+    # Since we don't want to actually run a server, we'll use a command that fails
+    config_data = {
+        "mcpServers": {
+            "bad_server": {
+                "command": "non_existent_command_xyz",
+                "args": []
+            }
+        }
+    }
+
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+        json.dump(config_data, f)
+        config_path = f.name
+
+    try:
+        # Should NOT raise exception, but log error
+        await manager.load_servers(config_path)
+        assert len(manager.sessions) == 0
+        assert len(manager.all_tools) == 0
+    finally:
+        os.unlink(config_path)
+        await manager.cleanup()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -127,9 +127,16 @@ def test_example_config_structure():
 
         # Check each server has required fields
         for _, server_config in config["mcpServers"].items():
-            assert "command" in server_config
-            assert "args" in server_config
-            assert isinstance(server_config["args"], list)
+            # Servers can be configured either as:
+            # - local process: {"command": "...", "args": [...], "env": {...}}
+            # - remote endpoint: {"url": "https://..."}
+            if "url" in server_config:
+                assert isinstance(server_config["url"], str)
+                assert server_config["url"], "Server url must be non-empty"
+            else:
+                assert "command" in server_config
+                assert "args" in server_config
+                assert isinstance(server_config["args"], list)
 
 def test_validate_cli_max_tool_rounds():
     """Test that validate_cli_inputs enforces max_tool_rounds validation."""


### PR DESCRIPTION
Relates to #23

- Add StreamableHTTP and SSE remote MCP server support via url config
- Implement ${env:VAR_NAME} and ${workspaceFolder} expansion in config strings
- Add robust error handling for config parsing and server connections
- Update README with remote server examples and expansion documentation
- Add tests for env expansion and error handling scenarios