### PR TITLE
feat: add OLLAMA_PROXY_TIMEOUT environment variable for configurable HTTP timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ This uses the included [docker-compose.yml](./docker-compose.yml) file which:
 - Connects to Ollama running on the host machine (`host.docker.internal:11434`)
 - Maps the configuration file from [./mcp-config.json](./mcp-config.json) (includes mock [weather server for demo](./mock-weather-mcp-server))
 - Allows all CORS origins (configurable via `CORS_ORIGINS` environment variable)
+- Supports configurable Ollama request timeouts via `OLLAMA_PROXY_TIMEOUT`
 
 
 ### Or, install from source
@@ -245,6 +246,12 @@ CORS_ORIGINS="http://localhost:3000,http://localhost:8080,https://app.example.co
   - Can be overridden with `--ollama-url` CLI parameter
   - Useful for Docker deployments and configuration management
   - Example: `OLLAMA_URL=http://192.168.1.100:11434 ollama-mcp-bridge`
+- `OLLAMA_PROXY_TIMEOUT`: Timeout for HTTP requests sent to Ollama, in **milliseconds** (default: unset)
+  - When **unset**, the bridge keeps its existing behavior (some requests use library defaults; `/api/chat` is not timed out)
+  - When set to a value **> 0**, the timeout is applied to Ollama-bound HTTP requests
+  - When set to **0**, timeouts are disabled for Ollama HTTP requests (the bridge logs a warning)
+  - Streaming chat responses always use no timeout, even when this variable is set
+  - Example (10 minutes): `OLLAMA_PROXY_TIMEOUT=600000 ollama-mcp-bridge`
 - `SYSTEM_PROMPT`: Optional system prompt to prepend to all forwarded `/api/chat` requests
   - Can be set via the `SYSTEM_PROMPT` environment variable or `--system-prompt` CLI flag
   - If provided, the bridge will prepend a system message (role: `system`) to the beginning of the `messages` array for `/api/chat` requests unless the request already starts with a system message.

--- a/src/ollama_mcp_bridge/mcp_manager.py
+++ b/src/ollama_mcp_bridge/mcp_manager.py
@@ -9,7 +9,7 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.sse import sse_client
 from mcp.client.streamable_http import streamablehttp_client
-from .utils import expand_dict_env_vars
+from .utils import expand_dict_env_vars, get_ollama_proxy_timeout_config
 
 
 class MCPManager:
@@ -27,7 +27,8 @@ class MCPManager:
         self.ollama_url = ollama_url
         # Optional system prompt that can be prepended to messages
         self.system_prompt = system_prompt
-        self.http_client = httpx.AsyncClient()
+        is_set, timeout_seconds = get_ollama_proxy_timeout_config()
+        self.http_client = httpx.AsyncClient(timeout=timeout_seconds) if is_set else httpx.AsyncClient()
 
     async def load_servers(self, config_path: str):
         """Load and connect to all MCP servers from config"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -5,9 +5,6 @@ import tempfile
 import os
 from ollama_mcp_bridge.mcp_manager import MCPManager
 
-@pytest.fixture
-def anyio_backend():
-    return 'asyncio'
 
 @pytest.mark.anyio
 async def test_invalid_json_config():

--- a/tests/test_ollama_proxy_timeout_env.py
+++ b/tests/test_ollama_proxy_timeout_env.py
@@ -1,0 +1,263 @@
+import types
+
+import pytest
+
+
+def test_get_ollama_proxy_timeout_config_unset(monkeypatch):
+    monkeypatch.delenv("OLLAMA_PROXY_TIMEOUT", raising=False)
+
+    from ollama_mcp_bridge.utils import get_ollama_proxy_timeout_config
+
+    is_set, timeout_seconds = get_ollama_proxy_timeout_config()
+    assert is_set is False
+    assert timeout_seconds is None
+
+
+def test_get_ollama_proxy_timeout_config_ms(monkeypatch):
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "1500")
+
+    from ollama_mcp_bridge.utils import get_ollama_proxy_timeout_config
+
+    is_set, timeout_seconds = get_ollama_proxy_timeout_config()
+    assert is_set is True
+    assert timeout_seconds == 1.5
+
+
+def test_get_ollama_proxy_timeout_config_zero_disables(monkeypatch):
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "0")
+
+    import ollama_mcp_bridge.utils as utils
+
+    # Reset warn-once sentinel so this test is isolated.
+    monkeypatch.setattr(utils, "_ollama_proxy_timeout_disabled_warned", False)
+
+    is_set, timeout_seconds = utils.get_ollama_proxy_timeout_config()
+    assert is_set is True
+    assert timeout_seconds is None
+
+
+def test_check_ollama_health_respects_env_override(monkeypatch):
+    import ollama_mcp_bridge.utils as utils
+
+    class DummyResp:
+        status_code = 200
+
+    called = {}
+
+    def fake_get(url, timeout):
+        called["timeout"] = timeout
+        return DummyResp()
+
+    monkeypatch.setattr(utils.httpx, "get", fake_get)
+
+    # Env unset -> uses function arg
+    monkeypatch.delenv("OLLAMA_PROXY_TIMEOUT", raising=False)
+    assert utils.check_ollama_health("http://localhost:11434", timeout=7) is True
+    assert called["timeout"] == 7
+
+    # Env set -> overrides function arg
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "1234")
+    assert utils.check_ollama_health("http://localhost:11434", timeout=7) is True
+    assert called["timeout"] == 1.234
+
+    # Env 0 -> explicitly disables
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "0")
+    monkeypatch.setattr(utils, "_ollama_proxy_timeout_disabled_warned", False)
+    assert utils.check_ollama_health("http://localhost:11434", timeout=7) is True
+    assert called["timeout"] is None
+
+
+def test_mcp_manager_http_client_timeout_from_env(monkeypatch):
+    import ollama_mcp_bridge.mcp_manager as mcp_manager_mod
+
+    constructed = []
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            constructed.append(kwargs.get("timeout", "__unset__"))
+
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr(mcp_manager_mod.httpx, "AsyncClient", DummyAsyncClient)
+
+    # Unset -> don't pass timeout
+    monkeypatch.delenv("OLLAMA_PROXY_TIMEOUT", raising=False)
+    constructed.clear()
+    _ = mcp_manager_mod.MCPManager()
+    assert constructed[-1] == "__unset__"
+
+    # Set -> pass seconds
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "1000")
+    constructed.clear()
+    _ = mcp_manager_mod.MCPManager()
+    assert constructed[-1] == 1.0
+
+    # 0 -> pass None (disable)
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "0")
+    constructed.clear()
+    _ = mcp_manager_mod.MCPManager()
+    assert constructed[-1] is None
+
+
+def test_proxy_service_http_client_timeout_from_env(monkeypatch):
+    import ollama_mcp_bridge.proxy_service as proxy_service_mod
+
+    constructed = []
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            constructed.append(kwargs.get("timeout", "__unset__"))
+
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr(proxy_service_mod.httpx, "AsyncClient", DummyAsyncClient)
+
+    class DummyMCPManager:
+        ollama_url = "http://localhost:11434"
+        all_tools = []
+        system_prompt = None
+
+    # Unset -> preserve existing behavior for /api/chat (timeout=None)
+    monkeypatch.delenv("OLLAMA_PROXY_TIMEOUT", raising=False)
+    constructed.clear()
+    _ = proxy_service_mod.ProxyService(DummyMCPManager())
+    assert constructed[-1] is None
+
+    # Set -> pass seconds
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "5000")
+    constructed.clear()
+    _ = proxy_service_mod.ProxyService(DummyMCPManager())
+    assert constructed[-1] == 5.0
+
+    # 0 -> pass None (disable)
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "0")
+    constructed.clear()
+    _ = proxy_service_mod.ProxyService(DummyMCPManager())
+    assert constructed[-1] is None
+
+
+@pytest.mark.anyio
+async def test_check_ollama_health_async_respects_env_override(monkeypatch):
+    import ollama_mcp_bridge.utils as utils
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.seen_timeout = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url, timeout):
+            self.seen_timeout = timeout
+            return types.SimpleNamespace(status_code=200)
+
+    dummy_client = DummyAsyncClient()
+
+    def fake_async_client(*args, **kwargs):
+        # Return the same instance so we can inspect it after the call.
+        return dummy_client
+
+    monkeypatch.setattr(utils.httpx, "AsyncClient", fake_async_client)
+
+    # Env unset -> uses function arg
+    monkeypatch.delenv("OLLAMA_PROXY_TIMEOUT", raising=False)
+    assert (
+        await utils.check_ollama_health_async("http://localhost:11434", timeout=9)
+        is True
+    )
+    assert dummy_client.seen_timeout == 9
+
+    # Env set -> overrides
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "2000")
+    assert (
+        await utils.check_ollama_health_async("http://localhost:11434", timeout=9)
+        is True
+    )
+    assert dummy_client.seen_timeout == 2.0
+
+    # Env 0 -> disables
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "0")
+    monkeypatch.setattr(utils, "_ollama_proxy_timeout_disabled_warned", False)
+    assert (
+        await utils.check_ollama_health_async("http://localhost:11434", timeout=9)
+        is True
+    )
+    assert dummy_client.seen_timeout is None
+
+
+@pytest.mark.anyio
+async def test_proxy_generic_request_sets_timeout_only_when_env_set(monkeypatch):
+    import ollama_mcp_bridge.proxy_service as proxy_service_mod
+
+    class DummyResponse:
+        def __init__(self):
+            self.content = b"{}"
+            self.status_code = 200
+            self.headers = {}
+
+    constructed_timeouts = []
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            constructed_timeouts.append(kwargs.get("timeout", "__unset__"))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def request(self, method, url, headers=None, params=None, content=None):
+            return DummyResponse()
+
+        async def aclose(self):
+            return None
+
+    monkeypatch.setattr(proxy_service_mod.httpx, "AsyncClient", DummyAsyncClient)
+
+    class DummyMCPManager:
+        ollama_url = "http://localhost:11434"
+        all_tools = []
+        system_prompt = None
+
+        async def call_tool(self, tool_name, arguments):
+            raise AssertionError("call_tool should not be used in this test")
+
+    svc = proxy_service_mod.ProxyService(DummyMCPManager())
+
+    class DummyRequest:
+        method = "POST"
+
+        def __init__(self):
+            self.headers = {"content-type": "application/json", "host": "example"}
+            self.query_params = {}
+
+        async def body(self):
+            return b"{}"
+
+    req = DummyRequest()
+
+    # Env unset -> do not pass timeout (httpx defaults)
+    monkeypatch.delenv("OLLAMA_PROXY_TIMEOUT", raising=False)
+    constructed_timeouts.clear()
+    await svc.proxy_generic_request("api/tags", req)
+    assert constructed_timeouts[-1] == "__unset__"
+
+    # Env set -> pass timeout seconds
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "2500")
+    constructed_timeouts.clear()
+    await svc.proxy_generic_request("api/tags", req)
+    assert constructed_timeouts[-1] == 2.5
+
+    # Env 0 -> pass timeout=None (disable)
+    monkeypatch.setenv("OLLAMA_PROXY_TIMEOUT", "0")
+    constructed_timeouts.clear()
+    await svc.proxy_generic_request("api/tags", req)
+    assert constructed_timeouts[-1] is None


### PR DESCRIPTION
Relates to #33 

Add configurable timeout for Ollama-bound HTTP requests via OLLAMA_PROXY_TIMEOUT environment variable (milliseconds). When unset, preserves existing behavior. When set to 0, disables timeouts with a warning. Streaming responses always use no timeout regardless of the setting.

- Add timeout parser and warn-once logic in utils.py
- Wire timeout into health checks (sync/async)
- Apply timeout to MCPManager and ProxyService HTTP clients
- Keep streaming explicitly timeout-free
- Document OLLAMA_PROXY_TIMEOUT in README with usage examples
- Add comprehensive test coverage for timeout behavior
- Centralize anyio_backend fixture in tests/conftest.py

Fixes timeout issues with large models on localhost.