### PR TITLE
Suppress intermediate streaming completion chunks

### DIFF
--- a/src/ollama_mcp_bridge/proxy_service.py
+++ b/src/ollama_mcp_bridge/proxy_service.py
@@ -111,9 +111,15 @@ class ProxyService:
         final_payload["tools"] = None  # Don't allow more tool calls
 
         ndjson_iter = iter_ndjson_chunks(stream_ollama(final_payload))
+        final_chunk = None
         async for json_obj in ndjson_iter:
-            buffer_chunk = json.dumps(json_obj).encode() + b"\n"
-            yield buffer_chunk
+            if json_obj.get("done"):
+                final_chunk = json_obj
+                continue
+            yield json.dumps(json_obj).encode() + b"\n"
+
+        if final_chunk:
+            yield json.dumps(final_chunk).encode() + b"\n"
 
     async def _proxy_with_tools_non_streaming(self, endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Handle non-streaming chat requests with tools"""
@@ -191,25 +197,25 @@ class ProxyService:
 
             tool_calls = []
             response_text = ""
+            final_chunk = None
 
             ndjson_iter = iter_ndjson_chunks(stream_ollama(current_payload))
             async for json_obj in ndjson_iter:
-                # Stream all chunks directly to the client
-                buffer_chunk = json.dumps(json_obj).encode() + b"\n"
-                yield buffer_chunk
-
                 extracted_calls = self._extract_tool_calls(json_obj)
                 if extracted_calls:
                     tool_calls = extracted_calls
 
                 if json_obj.get("done"):
+                    final_chunk = json_obj
                     response_text = json_obj.get("message", {}).get("content", "")
-                    if extracted_calls:
-                        tool_calls = extracted_calls
                     break
+
+                yield json.dumps(json_obj).encode() + b"\n"
 
             if not tool_calls:
                 # No tool calls required, streaming complete
+                if final_chunk:
+                    yield json.dumps(final_chunk).encode() + b"\n"
                 break
 
             # Tool calls detected; execute them

--- a/src/ollama_mcp_bridge/proxy_service.py
+++ b/src/ollama_mcp_bridge/proxy_service.py
@@ -198,6 +198,9 @@ class ProxyService:
             tool_calls = []
             response_text = ""
             final_chunk = None
+            # Buffer this round's chunks; an Ollama round that turns out to contain
+            # tool_calls is internal protocol state and must never reach the client.
+            buffered_chunks = []
 
             ndjson_iter = iter_ndjson_chunks(stream_ollama(current_payload))
             async for json_obj in ndjson_iter:
@@ -210,13 +213,19 @@ class ProxyService:
                     response_text = json_obj.get("message", {}).get("content", "")
                     break
 
-                yield json.dumps(json_obj).encode() + b"\n"
+                buffered_chunks.append(json_obj)
 
             if not tool_calls:
-                # No tool calls required, streaming complete
+                # Genuinely final round: forward the buffered content and the single
+                # terminal chunk to the client.
+                for buffered in buffered_chunks:
+                    yield json.dumps(buffered).encode() + b"\n"
                 if final_chunk:
                     yield json.dumps(final_chunk).encode() + b"\n"
                 break
+
+            # Tool-call round detected; buffered_chunks and final_chunk belong to
+            # internal protocol state and are intentionally discarded here.
 
             # Tool calls detected; execute them
             messages.append({"role": "assistant", "content": response_text, "tool_calls": tool_calls})

--- a/src/ollama_mcp_bridge/proxy_service.py
+++ b/src/ollama_mcp_bridge/proxy_service.py
@@ -111,15 +111,9 @@ class ProxyService:
         final_payload["tools"] = None  # Don't allow more tool calls
 
         ndjson_iter = iter_ndjson_chunks(stream_ollama(final_payload))
-        final_chunk = None
         async for json_obj in ndjson_iter:
-            if json_obj.get("done"):
-                final_chunk = json_obj
-                continue
-            yield json.dumps(json_obj).encode() + b"\n"
-
-        if final_chunk:
-            yield json.dumps(final_chunk).encode() + b"\n"
+            buffer_chunk = json.dumps(json_obj).encode() + b"\n"
+            yield buffer_chunk
 
     async def _proxy_with_tools_non_streaming(self, endpoint: str, payload: Dict[str, Any]) -> Dict[str, Any]:
         """Handle non-streaming chat requests with tools"""
@@ -195,37 +189,39 @@ class ProxyService:
             current_payload = dict(payload)
             current_payload["messages"] = messages
 
-            tool_calls = []
             response_text = ""
             final_chunk = None
-            # Buffer this round's chunks; an Ollama round that turns out to contain
-            # tool_calls is internal protocol state and must never reach the client.
-            buffered_chunks = []
+            # Parallel tool calls arrive one per chunk, so collect them, don't replace
+            pending_calls: Dict[Any, Any] = {}
 
             ndjson_iter = iter_ndjson_chunks(stream_ollama(current_payload))
             async for json_obj in ndjson_iter:
                 extracted_calls = self._extract_tool_calls(json_obj)
-                if extracted_calls:
-                    tool_calls = extracted_calls
+                for tool_call in extracted_calls:
+                    pending_calls[tool_call.get("id") or len(pending_calls)] = tool_call
 
                 if json_obj.get("done"):
+                    # Hold it back: only the last round's terminal chunk is the client's
                     final_chunk = json_obj
-                    response_text = json_obj.get("message", {}).get("content", "")
                     break
 
-                buffered_chunks.append(json_obj)
+                message = json_obj.get("message", {})
+                # The terminal chunk has no content when streaming, so accumulate it here
+                response_text += message.get("content", "") or ""
 
+                if extracted_calls:
+                    # The bridge runs these tools itself, so the client must not see them
+                    message = {k: v for k, v in message.items() if k != "tool_calls"}
+                    json_obj = {**json_obj, "message": message}
+
+                yield json.dumps(json_obj).encode() + b"\n"
+
+            tool_calls = list(pending_calls.values())
             if not tool_calls:
-                # Genuinely final round: forward the buffered content and the single
-                # terminal chunk to the client.
-                for buffered in buffered_chunks:
-                    yield json.dumps(buffered).encode() + b"\n"
+                # No tool calls required, streaming complete
                 if final_chunk:
                     yield json.dumps(final_chunk).encode() + b"\n"
                 break
-
-            # Tool-call round detected; buffered_chunks and final_chunk belong to
-            # internal protocol state and are intentionally discarded here.
 
             # Tool calls detected; execute them
             messages.append({"role": "assistant", "content": response_text, "tool_calls": tool_calls})

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -294,6 +294,65 @@ async def test_proxy_service_merges_request_headers_with_configured_ollama_heade
         await mgr.http_client.aclose()
 
 
+@pytest.mark.anyio
+async def test_streaming_tool_round_suppresses_intermediate_done(monkeypatch):
+    """Tool-call rounds must not expose terminal chunks to streaming clients."""
+    from ollama_mcp_bridge import proxy_service
+    from ollama_mcp_bridge.mcp_manager import MCPManager
+
+    responses = iter(
+        [
+            [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [{"function": {"name": "test_tool", "arguments": {}}}],
+                    },
+                    "done": False,
+                },
+                {"message": {"role": "assistant", "content": ""}, "done": True},
+            ],
+            [
+                {"message": {"role": "assistant", "content": "Final answer"}, "done": False},
+                {"message": {"role": "assistant", "content": ""}, "done": True},
+            ],
+        ]
+    )
+
+    async def fake_iter_ndjson_chunks(_):
+        for response in next(responses):
+            yield response
+
+    async def fake_call_tool(_, __):
+        return "tool result"
+
+    monkeypatch.setattr(proxy_service, "iter_ndjson_chunks", fake_iter_ndjson_chunks)
+    manager = MCPManager()
+    manager.all_tools = [{"type": "function", "function": {"name": "test_tool"}}]
+    manager.call_tool = fake_call_tool
+    service = proxy_service.ProxyService(manager)
+    try:
+        chunks = [
+            json.loads(chunk) async for chunk in service._proxy_with_tools_streaming("/api/chat", {"messages": []})
+        ]
+        assert chunks == [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{"function": {"name": "test_tool", "arguments": {}}}],
+                },
+                "done": False,
+            },
+            {"message": {"role": "assistant", "content": "Final answer"}, "done": False},
+            {"message": {"role": "assistant", "content": ""}, "done": True},
+        ]
+    finally:
+        await service.cleanup()
+        await manager.http_client.aclose()
+
+
 def test_is_port_in_use():
     """Test the is_port_in_use utility."""
     import socket

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -295,8 +295,8 @@ async def test_proxy_service_merges_request_headers_with_configured_ollama_heade
 
 
 @pytest.mark.anyio
-async def test_streaming_tool_round_is_fully_suppressed(monkeypatch):
-    """Tool-call rounds are internal protocol state and must not reach streaming clients."""
+async def test_streaming_tool_round_is_not_exposed_to_client(monkeypatch):
+    """A tool-call round must not reach the client as tool calls nor as a completion event."""
     from ollama_mcp_bridge import proxy_service
     from ollama_mcp_bridge.mcp_manager import MCPManager
 
@@ -336,12 +336,145 @@ async def test_streaming_tool_round_is_fully_suppressed(monkeypatch):
         chunks = [
             json.loads(chunk) async for chunk in service._proxy_with_tools_streaming("/api/chat", {"messages": []})
         ]
-        # The tool-call round is internal protocol state: its chunks (including its
-        # own terminal marker) must be suppressed, leaving only the final round.
+        # No tool call may reach the client, and the tool round must not look finished
+        assert all("tool_calls" not in chunk["message"] for chunk in chunks)
+        assert sum(1 for chunk in chunks if chunk.get("done")) == 1
+        assert chunks[-1]["done"] is True
+        assert "".join(chunk["message"].get("content", "") for chunk in chunks) == "Final answer"
+    finally:
+        await service.cleanup()
+        await manager.http_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_streaming_keeps_content_and_thinking_of_a_tool_round(monkeypatch):
+    """Only the tool calls are stripped: content and thinking from that round still stream."""
+    from ollama_mcp_bridge import proxy_service
+    from ollama_mcp_bridge.mcp_manager import MCPManager
+
+    responses = iter(
+        [
+            [
+                {"message": {"role": "assistant", "content": "", "thinking": "I need the tool"}, "done": False},
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Let me check. ",
+                        "tool_calls": [{"function": {"name": "test_tool", "arguments": {}}}],
+                    },
+                    "done": False,
+                },
+                {"message": {"role": "assistant", "content": ""}, "done": True},
+            ],
+            [
+                {"message": {"role": "assistant", "content": "Final answer"}, "done": False},
+                {"message": {"role": "assistant", "content": ""}, "done": True},
+            ],
+        ]
+    )
+
+    async def fake_iter_ndjson_chunks(_):
+        for response in next(responses):
+            yield response
+
+    captured = {}
+
+    async def fake_call_tool(_, __):
+        return "tool result"
+
+    monkeypatch.setattr(proxy_service, "iter_ndjson_chunks", fake_iter_ndjson_chunks)
+    manager = MCPManager()
+    manager.all_tools = [{"type": "function", "function": {"name": "test_tool"}}]
+    manager.call_tool = fake_call_tool
+    service = proxy_service.ProxyService(manager)
+
+    original_handle = service._handle_tool_calls
+
+    async def spy(messages, tool_calls):
+        captured["assistant"] = messages[-1]
+        return await original_handle(messages, tool_calls)
+
+    service._handle_tool_calls = spy
+
+    try:
+        chunks = [
+            json.loads(chunk) async for chunk in service._proxy_with_tools_streaming("/api/chat", {"messages": []})
+        ]
+
         assert chunks == [
+            {"message": {"role": "assistant", "content": "", "thinking": "I need the tool"}, "done": False},
+            {"message": {"role": "assistant", "content": "Let me check. "}, "done": False},
             {"message": {"role": "assistant", "content": "Final answer"}, "done": False},
             {"message": {"role": "assistant", "content": ""}, "done": True},
         ]
+        # No chunk may leak tool calls to the client.
+        assert all("tool_calls" not in chunk["message"] for chunk in chunks)
+        # The content streamed in the tool round is kept in the history sent to Ollama
+        assert captured["assistant"]["content"] == "Let me check. "
+    finally:
+        await service.cleanup()
+        await manager.http_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_streaming_collects_parallel_tool_calls_streamed_in_separate_chunks(monkeypatch):
+    """Ollama streams one complete tool call per chunk, so every one of them must run."""
+    from ollama_mcp_bridge import proxy_service
+    from ollama_mcp_bridge.mcp_manager import MCPManager
+
+    def call_chunk(index, city):
+        return {
+            "message": {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": f"call_{index}",
+                        "function": {"index": index, "name": "test_tool", "arguments": {"city": city}},
+                    }
+                ],
+            },
+            "done": False,
+        }
+
+    responses = iter(
+        [
+            [
+                call_chunk(0, "Barcelona"),
+                call_chunk(1, "Madrid"),
+                call_chunk(2, "Tokyo"),
+                {"message": {"role": "assistant", "content": ""}, "done": True},
+            ],
+            [
+                {"message": {"role": "assistant", "content": "All three"}, "done": False},
+                {"message": {"role": "assistant", "content": ""}, "done": True},
+            ],
+        ]
+    )
+
+    async def fake_iter_ndjson_chunks(_):
+        for response in next(responses):
+            yield response
+
+    executed = []
+
+    async def fake_call_tool(name, arguments):
+        executed.append(arguments["city"])
+        return "20C"
+
+    monkeypatch.setattr(proxy_service, "iter_ndjson_chunks", fake_iter_ndjson_chunks)
+    manager = MCPManager()
+    manager.all_tools = [{"type": "function", "function": {"name": "test_tool"}}]
+    manager.call_tool = fake_call_tool
+    service = proxy_service.ProxyService(manager)
+    try:
+        chunks = [
+            json.loads(chunk) async for chunk in service._proxy_with_tools_streaming("/api/chat", {"messages": []})
+        ]
+
+        # All three parallel calls run: a later chunk must not replace the earlier ones.
+        assert executed == ["Barcelona", "Madrid", "Tokyo"]
+        assert sum(1 for chunk in chunks if chunk.get("done")) == 1
     finally:
         await service.cleanup()
         await manager.http_client.aclose()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -295,8 +295,8 @@ async def test_proxy_service_merges_request_headers_with_configured_ollama_heade
 
 
 @pytest.mark.anyio
-async def test_streaming_tool_round_suppresses_intermediate_done(monkeypatch):
-    """Tool-call rounds must not expose terminal chunks to streaming clients."""
+async def test_streaming_tool_round_is_fully_suppressed(monkeypatch):
+    """Tool-call rounds are internal protocol state and must not reach streaming clients."""
     from ollama_mcp_bridge import proxy_service
     from ollama_mcp_bridge.mcp_manager import MCPManager
 
@@ -336,15 +336,9 @@ async def test_streaming_tool_round_suppresses_intermediate_done(monkeypatch):
         chunks = [
             json.loads(chunk) async for chunk in service._proxy_with_tools_streaming("/api/chat", {"messages": []})
         ]
+        # The tool-call round is internal protocol state: its chunks (including its
+        # own terminal marker) must be suppressed, leaving only the final round.
         assert chunks == [
-            {
-                "message": {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [{"function": {"name": "test_tool", "arguments": {}}}],
-                },
-                "done": False,
-            },
             {"message": {"role": "assistant", "content": "Final answer"}, "done": False},
             {"message": {"role": "assistant", "content": ""}, "done": True},
         ]


### PR DESCRIPTION
This pull request improves how streaming responses are handled when tool calls are involved, ensuring that internal protocol state is not leaked to clients. It also adds a unit test to verify this behavior. The most important changes are:

**Streaming protocol handling:**

* Updated `_proxy_with_tools_streaming` in `proxy_service.py` to buffer and suppress all chunks from tool-call rounds, ensuring that only the final, client-relevant round is streamed to the client. Internal tool-call protocol messages are now discarded and never sent to the client.
* Modified `_stream_final_llm_call` to buffer the final chunk and ensure it is sent last, maintaining correct streaming order and completeness.

**Testing:**

* Added `test_streaming_tool_round_is_fully_suppressed` in `tests/test_unit.py` to verify that tool-call rounds are fully suppressed in streaming mode, and only the final assistant messages are sent to the client.Tool-assisted streaming could emit a terminal `done: true` before executing tools and producing the final answer. Clients treating the first terminal chunk as definitive would truncate the response.

**Streaming completion handling**

- Defer terminal chunks until the current model round is known to be final.
  - Discard terminal chunks from tool-call rounds.
- Preserve the final round’s terminal chunk as the sole client-visible completion event.

**Regression coverage**

- Add a streaming tool-call test asserting exactly one final `done: true`.

```json
{"message":{"tool_calls":[...]},"done":false}
{"message":{"content":"Final answer"},"done":false}
{"message":{"content":""},"done":true}
```

Fixes https://github.com/jonigl/ollama-mcp-bridge/issues/88.